### PR TITLE
fix: add missing environment variables configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,21 @@ cd ../wata-board-dapp
 npm install
 ```
 
-### 2. Run Frontend (Development)
+### 2. Configure Environment Variables
+
+```bash
+# Setup frontend environment
+cd wata-board-frontend
+cp .env.example .env
+
+# Setup backend environment
+cd ../wata-board-dapp
+cp .env.example .env
+```
+
+Edit the `.env` files with your actual values. See the [Environment Variables](#environment-variables) section for detailed instructions.
+
+### 3. Run Frontend (Development)
 
 ```bash
 cd wata-board-frontend
@@ -49,7 +63,7 @@ npm run dev
 
 Open the URL shown (usually `http://localhost:5173`)
 
-### 3. Run Dapp (Backend)
+### 4. Run Dapp (Backend)
 
 ```bash
 cd wata-board-dapp
@@ -71,24 +85,43 @@ npx ts-node src/index.ts
 
 ## Environment Variables
 
-Create `.env` files for sensitive configuration:
+The project uses environment variables to manage configuration. Template files are provided for both frontend and backend components.
 
-### Frontend (.env)
-```
-VITE_CONTRACT_ID=CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA
-VITE_RPC_URL=https://soroban-testnet.stellar.org
-```
+### Setup Instructions
 
-### Dapp (.env)
-```bash
-# Stellar secret key for the admin account
-# This key controls access to administrative functions of the smart contract
-ADMIN_SECRET_KEY=your_stellar_secret_key_here
+1. **Frontend Environment Setup**:
+   ```bash
+   cd wata-board-frontend
+   cp .env.example .env
+   ```
+   Edit `.env` with your configuration:
+   ```bash
+   VITE_CONTRACT_ID=CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA
+   VITE_RPC_URL=https://soroban-testnet.stellar.org
+   ```
 
-# Contract configuration
-CONTRACT_ID=CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA
-RPC_URL=https://soroban-testnet.stellar.org
-```
+2. **Backend Environment Setup**:
+   ```bash
+   cd wata-board-dapp
+   cp .env.example .env
+   ```
+   Edit `.env` with your configuration:
+   ```bash
+   ADMIN_SECRET_KEY=your_stellar_secret_key_here
+   CONTRACT_ID=CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA
+   RPC_URL=https://soroban-testnet.stellar.org
+   ```
+
+### Required Variables
+
+#### Frontend (.env)
+- `VITE_CONTRACT_ID`: Stellar contract ID for the Wata Board smart contract
+- `VITE_RPC_URL`: RPC endpoint for Stellar Soroban network connection
+
+#### Backend (.env)
+- `ADMIN_SECRET_KEY`: Stellar secret key for admin account (controls contract access)
+- `CONTRACT_ID`: Stellar contract ID for the Wata Board smart contract  
+- `RPC_URL`: RPC endpoint for Stellar Soroban network connection
 
 ⚠️ **Security**: Never commit `.env` files with real keys to git! Use `.env.example` as a template and create your own `.env` file.
 

--- a/wata-board-dapp/.env.example
+++ b/wata-board-dapp/.env.example
@@ -5,3 +5,15 @@
 # This key controls access to administrative functions of the smart contract
 # IMPORTANT: Never commit this file to version control or share the secret key
 ADMIN_SECRET_KEY=your_stellar_secret_key_here
+
+# Contract Configuration
+# The contract ID for the Wata Board smart contract on Stellar network
+CONTRACT_ID=CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA
+
+# Stellar RPC URL
+# The RPC endpoint for connecting to the Stellar Soroban network
+RPC_URL=https://soroban-testnet.stellar.org
+
+# Network Configuration (Optional)
+# Network passphrase for Stellar network
+# NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/wata-board-frontend/.env.example
+++ b/wata-board-frontend/.env.example
@@ -1,0 +1,18 @@
+# Environment Variables for Wata Board Frontend
+# Copy this file to .env and fill in your actual values
+
+# Stellar Contract Configuration
+# The contract ID for the Wata Board smart contract on Stellar network
+VITE_CONTRACT_ID=CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA
+
+# Stellar RPC URL
+# The RPC endpoint for connecting to the Stellar Soroban network
+VITE_RPC_URL=https://soroban-testnet.stellar.org
+
+# Network Configuration (Optional)
+# Uncomment and modify for different networks
+# VITE_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Application Settings (Optional)
+# VITE_APP_NAME=Wata-Board
+# VITE_APP_VERSION=1.0.0


### PR DESCRIPTION
- Add .env.example file for frontend with VITE_CONTRACT_ID and VITE_RPC_URL
- Update existing .env.example for backend with CONTRACT_ID and RPC_URL
- Improve README with detailed environment setup instructions
- Add environment configuration step to Quick Start guide

Fixes issue where developers had to guess required environment variables
 closes #2