### PR TITLE
feat: implement log aggregation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 .env.production
 .env.development
 
-# Configuration snapshots (may contain env values – never commit)
-logs/config-snapshot.json
+# Logs — never commit log files or rotated archives
+logs/
+*.log
+*.log.gz
 
 # Dependencies
 node_modules/
@@ -27,3 +29,6 @@ build/
 # OS
 .DS_Store
 Thumbs.db
+
+# Local issue tracking files
+issue.md

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,8 @@
     "helmet": "^7.0.0",
     "ioredis": "^5.10.1",
     "pg": "^8.11.3",
+    "winston": "^3.11.0",
+    "winston-daily-rotate-file": "^5.0.0",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/backend/src/__tests__/logger.test.ts
+++ b/backend/src/__tests__/logger.test.ts
@@ -1,0 +1,91 @@
+import http from 'http';
+
+jest.mock('winston-daily-rotate-file', () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    write: jest.fn(),
+    end: jest.fn(),
+  }));
+});
+
+describe('Logger', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.LOG_AGGREGATION_URL;
+    delete process.env.LOG_AGGREGATION_API_KEY;
+  });
+
+  it('exports a logger with standard log methods', async () => {
+    const { default: logger } = await import('../utils/logger');
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.error).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.debug).toBe('function');
+  });
+
+  it('includes combined, application, error, audit, and console transports by default', async () => {
+    const { default: logger } = await import('../utils/logger');
+    // Console + combined + application + error + audit = 5
+    expect(logger.transports.length).toBe(5);
+  });
+
+  it('adds HTTP aggregation transport when LOG_AGGREGATION_URL is set', async () => {
+    process.env.LOG_AGGREGATION_URL = 'http://localhost:9200/logs';
+    const { default: logger } = await import('../utils/logger');
+    expect(logger.transports.length).toBe(6);
+  });
+
+  it('auditLogger.log calls logger with AUDIT prefix and audit metadata', async () => {
+    const { default: logger, auditLogger } = await import('../utils/logger');
+    const spy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    auditLogger.log('user_login', { userId: '42' });
+
+    expect(spy).toHaveBeenCalledWith(
+      '[AUDIT] user_login',
+      expect.objectContaining({ audit: true, userId: '42', event_timestamp: expect.any(String) })
+    );
+    spy.mockRestore();
+  });
+
+  it('HttpAggregationTransport posts log entry to aggregation URL', async () => {
+    process.env.LOG_AGGREGATION_URL = 'http://localhost:9200/logs';
+
+    const mockEnd = jest.fn();
+    const mockWrite = jest.fn();
+    const mockRequest = jest.spyOn(http, 'request').mockReturnValue({
+      on: jest.fn(),
+      write: mockWrite,
+      end: mockEnd,
+    } as any);
+
+    const { default: logger } = await import('../utils/logger');
+    logger.info('test aggregation');
+
+    // Allow the setImmediate inside log() to fire
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockRequest).toHaveBeenCalled();
+    expect(mockWrite).toHaveBeenCalled();
+    expect(mockEnd).toHaveBeenCalled();
+
+    mockRequest.mockRestore();
+  });
+
+  it('HttpAggregationTransport includes Authorization header when API key is set', async () => {
+    process.env.LOG_AGGREGATION_URL = 'http://localhost:9200/logs';
+    process.env.LOG_AGGREGATION_API_KEY = 'secret-token';
+
+    const mockRequest = jest.spyOn(http, 'request').mockReturnValue({
+      on: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn(),
+    } as any);
+
+    await import('../utils/logger');
+    const [[options]] = mockRequest.mock.calls as any;
+
+    expect(options.headers?.Authorization).toBe('Bearer secret-token');
+    mockRequest.mockRestore();
+  });
+});

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,10 +1,50 @@
 import winston from 'winston';
 import DailyRotateFile from 'winston-daily-rotate-file';
 import path from 'path';
+import https from 'https';
+import http from 'http';
+import Transport from 'winston-transport';
 
-/**
- * Custom log format including timestamp, level, message, and structured context.
- */
+// Ships log entries to an external aggregation endpoint (ELK, Loki, Splunk, etc.)
+// Activated only when LOG_AGGREGATION_URL is set. Failures are silently swallowed
+// so that a dead aggregator never crashes the application.
+class HttpAggregationTransport extends Transport {
+  private aggregationUrl: URL;
+
+  constructor(opts: ConstructorParameters<typeof Transport>[0] & { url: string }) {
+    super(opts);
+    this.aggregationUrl = new URL(opts.url);
+  }
+
+  log(info: Record<string, unknown>, callback: () => void): void {
+    setImmediate(() => this.emit('logged', info));
+
+    const body = JSON.stringify(info);
+    const isHttps = this.aggregationUrl.protocol === 'https:';
+    const options: http.RequestOptions = {
+      hostname: this.aggregationUrl.hostname,
+      port: this.aggregationUrl.port || (isHttps ? 443 : 80),
+      path: this.aggregationUrl.pathname + this.aggregationUrl.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        ...(process.env.LOG_AGGREGATION_API_KEY && {
+          Authorization: `Bearer ${process.env.LOG_AGGREGATION_API_KEY}`,
+        }),
+      },
+    };
+
+    const transport = isHttps ? https : http;
+    const req = transport.request(options);
+    req.on('error', () => {});
+    req.write(body);
+    req.end();
+
+    callback();
+  }
+}
+
 const logFormat = winston.format.printf(({ timestamp, level, message, ...metadata }) => {
   let msg = `${timestamp} [${level}] : ${message} `;
   if (Object.keys(metadata).length > 0) {
@@ -13,14 +53,63 @@ const logFormat = winston.format.printf(({ timestamp, level, message, ...metadat
   return msg;
 });
 
-/**
- * Production-grade logger for the backend.
- * Features:
- * - JSON output for machine readability (e.g., Splunk, ELK)
- * - Daily file rotation for logs to prevent disk space issues
- * - Multi-transport: Console and File
- * - Context/Metadata support
- */
+const transports: winston.transport[] = [
+  // Console — colorized for local dev, readable by container orchestrators (Docker/K8s)
+  new winston.transports.Console({
+    format: winston.format.combine(
+      winston.format.colorize(),
+      winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+      logFormat
+    ),
+  }),
+
+  // Combined — single stream with all levels for easy local debugging
+  new DailyRotateFile({
+    filename: path.join('logs', 'combined-%DATE%.log'),
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: true,
+    maxSize: '20m',
+    maxFiles: '14d',
+  }),
+
+  // Application — info and above
+  new DailyRotateFile({
+    filename: path.join('logs', 'application-%DATE%.log'),
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: true,
+    maxSize: '20m',
+    maxFiles: '14d',
+    level: 'info',
+  }),
+
+  // Error — errors only, longer retention
+  new DailyRotateFile({
+    filename: path.join('logs', 'error-%DATE%.log'),
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: true,
+    maxSize: '20m',
+    maxFiles: '30d',
+    level: 'error',
+  }),
+
+  // Audit — security-sensitive events, 1-year retention
+  new DailyRotateFile({
+    filename: path.join('logs', 'audit-%DATE%.log'),
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: true,
+    maxSize: '50m',
+    maxFiles: '365d',
+    level: 'info',
+  }),
+];
+
+// Opt-in external aggregation: set LOG_AGGREGATION_URL to enable
+if (process.env.LOG_AGGREGATION_URL) {
+  transports.push(
+    new HttpAggregationTransport({ url: process.env.LOG_AGGREGATION_URL })
+  );
+}
+
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format: winston.format.combine(
@@ -29,61 +118,18 @@ const logger = winston.createLogger({
     winston.format.json()
   ),
   defaultMeta: { service: 'wata-board-api' },
-  transports: [
-    // Console transport for development and container orchestration (Docker/K8s)
-    new winston.transports.Console({
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-        logFormat
-      )
-    }),
-    
-    // File rotation for persisting info level and above
-    new DailyRotateFile({
-      filename: path.join('logs', 'application-%DATE%.log'),
-      datePattern: 'YYYY-MM-DD',
-      zippedArchive: true,
-      maxSize: '20m',
-      maxFiles: '14d',
-      level: 'info'
-    }),
-
-    // Separate file for persistent error logs
-    new DailyRotateFile({
-      filename: path.join('logs', 'error-%DATE%.log'),
-      datePattern: 'YYYY-MM-DD',
-      zippedArchive: true,
-      maxSize: '20m',
-      maxFiles: '30d',
-      level: 'error'
-    }),
-
-    // Dedicated Audit Log transport - longer retention, strictly JSON
-    new DailyRotateFile({
-      filename: path.join('logs', 'audit-%DATE%.log'),
-      datePattern: 'YYYY-MM-DD',
-      zippedArchive: true,
-      maxSize: '50m',
-      maxFiles: '365d', // Audit logs kept for 1 year
-      level: 'info'
-    })
-  ]
+  transports,
 });
 
-/**
- * Convenience logger for audit-specific events (security sensitive).
- * Automatically includes high-level audit tagging.
- */
 export const auditLogger = {
-  log: (message: string, meta?: any) => {
-    logger.info(`[AUDIT] ${message}`, { 
-      ...meta, 
+  log: (message: string, meta?: Record<string, unknown>) => {
+    logger.info(`[AUDIT] ${message}`, {
+      ...meta,
       audit: true,
       event_timestamp: new Date().toISOString(),
-      environment: process.env.NODE_ENV || 'development'
+      environment: process.env.NODE_ENV || 'development',
     });
-  }
+  },
 };
 
 export default logger;


### PR DESCRIPTION
## Summary

Closes #165

- Add `winston` and `winston-daily-rotate-file` as proper dependencies (were imported but missing from `package.json`)
- Add `combined-%DATE%.log` transport — single centralized stream of all log levels for easy debugging
- Add opt-in `HttpAggregationTransport` that ships logs to any external aggregator (ELK, Loki, Splunk) via `LOG_AGGREGATION_URL` env var; silently no-ops if the endpoint is unavailable so it never crashes the app
- Add `LOG_AGGREGATION_API_KEY` support for authenticated endpoints
- Add logger unit tests covering transports, `auditLogger`, and HTTP transport behavior
- Update `.gitignore` to exclude `logs/`, `*.log`, and `*.log.gz` files from being committed

## Test plan

- [ ] Run `npm install` in `backend/` to confirm winston deps resolve
- [ ] Run `npx jest src/__tests__/logger.test.ts` — all 5 tests should pass
- [ ] Start the server and confirm `logs/combined-*.log` is created on first request
- [ ] Set `LOG_AGGREGATION_URL=http://your-endpoint/ingest` and confirm logs are shipped externally
- [ ] Confirm `logs/` is not tracked by git (`git status` should not show log files)