### PR TITLE
Metrics Collection Enhancement

### DIFF
--- a/backend/src/middleware/metrics.ts
+++ b/backend/src/middleware/metrics.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 export interface ApiMetric {
   timestamp: number;
@@ -27,13 +27,31 @@ export interface SystemHealth {
   averageDatabaseQueryTime: number;
 }
 
+// Prometheus histogram buckets for response times (in ms)
+const HISTOGRAM_BUCKETS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+
+function getBucketIndex (value: number): number {
+  for (let i = 0; i < HISTOGRAM_BUCKETS.length; i++) {
+    if (value <= HISTOGRAM_BUCKETS[i]) return i;
+  }
+  return HISTOGRAM_BUCKETS.length;
+}
+
 class MetricsCollector {
   private metrics: ApiMetric[] = [];
   private databaseMetrics: DatabaseMetric[] = [];
   private readonly maxRetention = 10_000;
   private activeConnections = 0;
 
-  middleware() {
+  // Prometheus counters
+  private requestCountByMethod: Record<string, number> = {};
+  private requestCountByStatus: Record<number, number> = {};
+  private requestCountByPath: Record<string, number> = {};
+  private responseTimeHistogram: number[] = new Array(HISTOGRAM_BUCKETS.length + 1).fill(0);
+  private totalResponseTimeMs = 0;
+  private totalRequests = 0;
+
+  middleware () {
     return (req: Request, res: Response, next: NextFunction) => {
       const start = Date.now();
       this.activeConnections++;
@@ -41,24 +59,33 @@ class MetricsCollector {
 
       res.on('finish', () => {
         this.activeConnections--;
+        const responseTimeMs = Date.now() - start;
         const metric: ApiMetric = {
           timestamp: Date.now(),
           method: req.method,
           path: req.path,
           statusCode: res.statusCode,
-          responseTimeMs: Date.now() - start,
+          responseTimeMs,
           userId,
         };
         this.metrics.push(metric);
         if (this.metrics.length > this.maxRetention) {
           this.metrics = this.metrics.slice(-this.maxRetention);
         }
+
+        // Update Prometheus-style counters
+        this.requestCountByMethod[req.method] = (this.requestCountByMethod[req.method] || 0) + 1;
+        this.requestCountByStatus[res.statusCode] = (this.requestCountByStatus[res.statusCode] || 0) + 1;
+        this.requestCountByPath[`${req.method} ${req.path}`] = (this.requestCountByPath[`${req.method} ${req.path}`] || 0) + 1;
+        this.responseTimeHistogram[getBucketIndex(responseTimeMs)]++;
+        this.totalResponseTimeMs += responseTimeMs;
+        this.totalRequests++;
       });
       next();
     };
   }
 
-  recordDatabaseQuery(durationMs: number, success: boolean) {
+  recordDatabaseQuery (durationMs: number, success: boolean) {
     const metric: DatabaseMetric = {
       timestamp: Date.now(),
       durationMs,
@@ -70,17 +97,17 @@ class MetricsCollector {
     }
   }
 
-  getMetrics(windowMs = 60_000): ApiMetric[] {
+  getMetrics (windowMs = 60_000): ApiMetric[] {
     const cutoff = Date.now() - windowMs;
     return this.metrics.filter((m) => m.timestamp > cutoff);
   }
 
-  getDatabaseMetrics(windowMs = 60_000): DatabaseMetric[] {
+  getDatabaseMetrics (windowMs = 60_000): DatabaseMetric[] {
     const cutoff = Date.now() - windowMs;
     return this.databaseMetrics.filter((m) => m.timestamp > cutoff);
   }
 
-  getSystemHealth(): SystemHealth {
+  getSystemHealth (): SystemHealth {
     const recentMetrics = this.getMetrics(60_000);
     const recentDbMetrics = this.getDatabaseMetrics(60_000);
     const errors = recentMetrics.filter((m) => m.statusCode >= 400);
@@ -109,7 +136,7 @@ class MetricsCollector {
     };
   }
 
-  getUserMetrics(windowMs = 60_000): Record<string, { count: number; errors: number }> {
+  getUserMetrics (windowMs = 60_000): Record<string, { count: number; errors: number }> {
     const recent = this.getMetrics(windowMs);
     const result: Record<string, { count: number; errors: number }> = {};
     for (const m of recent) {
@@ -120,7 +147,7 @@ class MetricsCollector {
     return result;
   }
 
-  getEndpointMetrics(windowMs = 60_000): Record<string, { count: number; avgResponseMs: number }> {
+  getEndpointMetrics (windowMs = 60_000): Record<string, { count: number; avgResponseMs: number }> {
     const recent = this.getMetrics(windowMs);
     const agg: Record<string, { count: number; totalMs: number; avgResponseMs: number }> = {};
     for (const m of recent) {
@@ -131,6 +158,65 @@ class MetricsCollector {
       agg[key].avgResponseMs = Math.round(agg[key].totalMs / agg[key].count);
     }
     return agg;
+  }
+
+  /**
+   * Export metrics in Prometheus text format for scraping
+   */
+  getPrometheusMetrics (): string {
+    const lines: string[] = [];
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    // HTTP request counters
+    for (const [method, count] of Object.entries(this.requestCountByMethod)) {
+      lines.push(`http_requests_total{method="${method}"} ${count}`);
+    }
+
+    // Status code counters
+    for (const [status, count] of Object.entries(this.requestCountByStatus)) {
+      lines.push(`http_requests_by_status_total{status="${status}"} ${count}`);
+    }
+
+    // Response time histogram
+    let cumulative = 0;
+    for (let i = 0; i < HISTOGRAM_BUCKETS.length; i++) {
+      cumulative += this.responseTimeHistogram[i];
+      const upper = HISTOGRAM_BUCKETS[i];
+      lines.push(`http_response_time_seconds_bucket{le="${upper}"} ${cumulative}`);
+    }
+    // +Inf bucket
+    lines.push(`http_response_time_seconds_bucket{le="+Inf"} ${this.totalRequests}`);
+
+    // Summary quantiles (approximate)
+    if (this.totalRequests > 0) {
+      const avgMs = this.totalResponseTimeMs / this.totalRequests;
+      lines.push(`http_response_time_seconds_sum ${(avgMs / 1000).toFixed(6)}`);
+      lines.push(`http_response_time_seconds_count ${this.totalRequests}`);
+    }
+
+    return lines.join('\n') + '\n';
+  }
+
+  /**
+   * Get histogram bucket distribution
+   */
+  getHistogramBuckets (): { buckets: number[]; labels: string[] } {
+    return {
+      buckets: [...this.responseTimeHistogram],
+      labels: [...HISTOGRAM_BUCKETS.map(String), '+Inf'],
+    };
+  }
+
+  /**
+   * Reset counters (useful for testing)
+   */
+  resetCounters () {
+    this.requestCountByMethod = {};
+    this.requestCountByStatus = {};
+    this.requestCountByPath = {};
+    this.responseTimeHistogram = new Array(HISTOGRAM_BUCKETS.length + 1).fill(0);
+    this.totalResponseTimeMs = 0;
+    this.totalRequests = 0;
   }
 }
 

--- a/backend/src/routes/monitoring.ts
+++ b/backend/src/routes/monitoring.ts
@@ -9,19 +9,27 @@
  * /api/monitoring/users           – list all user tiers (admin)
  */
 
-import { Router, Request, Response } from 'express';
-import { monitoringService } from '../services/monitoringService';
-import type { AlertConfig as MonitoringAlertConfig } from '../services/monitoringService';
-import { tieredRateLimiter } from '../middleware/rateLimiter';
-import { userTierService } from '../services/userTierService';
+import { Request, Response, Router } from 'express';
 import {
-  sanitizeAlphanumeric,
-  sanitizeWalletAddress,
-  sanitizeString,
   allowKeys,
+  sanitizeAlphanumeric,
+  sanitizeString,
+  sanitizeWalletAddress,
 } from '../utils/sanitize';
 
+import type { AlertConfig as MonitoringAlertConfig } from '../services/monitoringService';
+import { metricsCollector } from '../middleware/metrics';
+import { monitoringService } from '../services/monitoringService';
+import { tieredRateLimiter } from '../middleware/rateLimiter';
+import { userTierService } from '../services/userTierService';
+
 const router = Router();
+
+/** GET /api/monitoring/prometheus - Prometheus metrics export */
+router.get('/prometheus', (_req: Request, res: Response) => {
+  res.set('Content-Type', 'text/plain; charset=utf-8');
+  res.send(metricsCollector.getPrometheusMetrics());
+});
 
 /** GET /api/monitoring/health */
 router.get('/health', (_req: Request, res: Response) => {


### PR DESCRIPTION
Closes #166

---

### Summary
Added Prometheus-compatible metrics export to enhance observability.

### Changes
- **metrics.ts**: Added Prometheus-style counters (by method, status, path) and response time histogram with configurable buckets
- **monitoring.ts**: Added `/api/monitoring/prometheus` endpoint for Prometheus scraping

### New Features
- `getPrometheusMetrics()` - Export metrics in Prometheus text format
- `getHistogramBuckets()` - Get bucket distribution
- `resetCounters()` - Reset counters (for testing)

### Testing
```bash
curl http://localhost:3001/api/monitoring/prometheus