### PR TITLE
Implement transaction deduplication with nonces to prevent replay att…

### DIFF
--- a/backend/src/payment-service.ts
+++ b/backend/src/payment-service.ts
@@ -13,6 +13,7 @@ export interface PaymentRequest {
   amount: number;
   userId: string;
   memo?: string;
+  nonce: string; // Unique nonce to prevent replay attacks
 }
 
 // Updated interface using standardized types
@@ -27,7 +28,8 @@ function convertToStandardRequest(legacyRequest: PaymentRequest): SharedPaymentR
     meterId: legacyRequest.meter_id,
     amount: legacyRequest.amount,
     userId: legacyRequest.userId,
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
+    nonce: legacyRequest.nonce
   };
 }
 
@@ -259,7 +261,8 @@ export class PaymentService {
     const tx = await client.pay_bill({
       meter_id: request.meter_id,
       amount: request.amount,
-      memo: request.memo
+      memo: request.memo,
+      nonce: request.nonce
     });
 
     // For backend processing, we'd need to sign with the admin key

--- a/contract/nepa_client_v2/src/index.ts
+++ b/contract/nepa_client_v2/src/index.ts
@@ -49,7 +49,7 @@ export interface Client {
   /**
    * Construct and simulate a pay_bill transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  pay_bill: ({meter_id, amount, memo}: {meter_id: string, amount: u32, memo?: string}, options?: MethodOptions) => Promise<AssembledTransaction<null>>
+  pay_bill: ({meter_id, amount, memo, nonce}: {meter_id: string, amount: u32, memo?: string, nonce: string}, options?: MethodOptions) => Promise<AssembledTransaction<null>>
 
   /**
    * Construct and simulate a get_total_paid transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -71,6 +71,7 @@ pub struct PaymentRecord {
     pub meter_id: String,
     pub timestamp: u64,
     pub memo: Option<String>,
+    pub nonce: String,
     pub refunded: bool,
     pub is_refunded: bool,
     pub refund_id: Option<u32>,
@@ -173,17 +174,23 @@ impl NepaBillingContract {
             .unwrap_or_else(|| panic!("Contract not initialized"))
     }
     
-    pub fn pay_bill(env: Env, from: Address, token_address: Address, meter_id: String, amount: i128, memo: Option<String>) -> u64 {
+    pub fn pay_bill(env: Env, from: Address, token_address: Address, meter_id: String, amount: i128, memo: Option<String>, nonce: String) -> u64 {
         // 1. Verify the user authorized this payment
         from.require_auth();
 
-        // 2. Initialize the Token client
+        // 2. Check nonce uniqueness to prevent replay attacks
+        let nonce_key = (Symbol::short("NONCE"), from.clone(), nonce.clone());
+        if env.storage().persistent().has(&nonce_key) {
+            panic!("Nonce already used - potential replay attack");
+        }
+
+        // 3. Initialize the Token client
         let token_client = token::Client::new(&env, &token_address);
 
-        // 3. Move the tokens from the User to the Contract
+        // 4. Move the tokens from the User to the Contract
         token_client.transfer(&from, &env.current_contract_address(), &amount);
 
-        // 4. Create payment record
+        // 5. Create payment record
         let payment_id = Self::_generate_payment_id(&env);
         let timestamp = env.ledger().timestamp();
         
@@ -193,19 +200,31 @@ impl NepaBillingContract {
             meter_id: meter_id.clone(),
             timestamp,
             memo,
+            nonce: nonce.clone(),
             refunded: false,
             is_refunded: false,
             refund_id: None,
         };
 
-        // 5. Store payment record
+        // 6. Store payment record
         env.storage().persistent().set(&payment_id, &payment_record);
 
-        // 6. Update the meter total (backward compatibility)
+        // 7. Mark nonce as used
+        env.storage().persistent().set(&nonce_key, &true);
+
+        // 8. Update the meter total (backward compatibility)
         let current_total: i128 = env.storage().persistent().get(&meter_id).unwrap_or(0);
         env.storage().persistent().set(&meter_id, &(current_total + amount));
 
         payment_id
+    }
+
+    /// Generate unique payment ID
+    fn _generate_payment_id(env: &Env) -> u64 {
+        let counter: u64 = env.storage().persistent().get(&PAYMENT_COUNTER).unwrap_or(0);
+        let new_id = counter + 1;
+        env.storage().persistent().set(&PAYMENT_COUNTER, &new_id);
+        new_id
     }
 
     pub fn get_total_paid(env: Env, meter_id: String) -> i128 {

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
+
     fn test_payment_and_refund_flow() {
         let env = create_test_env();
         let (admin, user, approver1, approver2) = setup_contract_with_refund_config(&env);
@@ -295,22 +295,22 @@ mod tests {
         let unauthorized_approver = TestAddress::generate(&env);
         let token_address = TestAddress::generate(&env);
         
-=======
+
     fn test_pay_bill_and_records() {
         let (env, client, admin) = setup_test();
         client.initialize(&admin);
         
         let user = TestAddress::generate(&env);
         let token_address = TestAddress::generate(&env);
->>>>>>> 7c6957b887aad2d7d8e9ecedd6292ce5fc776e6f
+
         let meter_id = String::from_str(&env, "METER-001");
         let amount = 1000i128;
         
         // Payment 1
-        let payment1 = client.pay_bill(&user, &token_address, &meter_id, &amount);
+        let payment1 = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         assert_eq!(payment1, 1);
         
-<<<<<<< HEAD
+
         // Request refund
         let refund_id = NepaBillingContract::request_refund(
             env.clone(),
@@ -322,7 +322,7 @@ mod tests {
         // Try to approve with unauthorized approver (should fail)
         let result = std::panic::catch_unwind(|| {
             NepaBillingContract::approve_refund(env.clone(), unauthorized_approver.clone(), refund_id);
-=======
+
         // Verify record
         let record = client.get_payment_record(&payment1);
         assert_eq!(record.payer, user);
@@ -342,7 +342,7 @@ mod tests {
         let meter_id = String::from_str(&env, "METER-001");
         
         // Payment
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         
         // 1. Unauthorized refund fails
         let non_admin = TestAddress::generate(&env);
@@ -456,7 +456,7 @@ mod tests {
         assert!(!client.verify_review(&user, &String::from_str(&env, "wrong-hash")));
     }
 
-    // ==================== REFUND MECHANISM TESTS ====================
+    // ====== REFUND MECHANISM TESTS ======
 
     #[test]
     fn test_refund_request_creation() {
@@ -469,7 +469,7 @@ mod tests {
         let amount = 1000i128;
         
         // Make a payment
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &amount);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         
         // Request refund
         let reason = String::from_str(&env, "wrong_meter_id");
@@ -495,33 +495,33 @@ mod tests {
         let token_address = TestAddress::generate(&env);
         let meter_id = String::from_str(&env, "METER-001");
         
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         
         // Try invalid reason
         let invalid_reason = String::from_str(&env, "invalid_reason");
         let result = std::panic::catch_unwind(|| {
             client.request_refund(&user, &payment_id, &invalid_reason);
->>>>>>> 7c6957b887aad2d7d8e9ecedd6292ce5fc776e6f
+
         });
         assert!(result.is_err());
     }
 
     #[test]
-<<<<<<< HEAD
+
     fn test_refund_history_tracking() {
         let env = create_test_env();
         let (_, user, _, _) = setup_contract_with_refund_config(&env);
-=======
+
     fn test_refund_request_wrong_payer() {
         let (env, client, admin) = setup_test();
         client.initialize(&admin);
         
         let user = TestAddress::generate(&env);
->>>>>>> 7c6957b887aad2d7d8e9ecedd6292ce5fc776e6f
+
         let token_address = TestAddress::generate(&env);
         let meter_id = String::from_str(&env, "METER-001");
         
-<<<<<<< HEAD
+
         let meter_id = String::from_str(&env, "METER-001");
         let amount = 1000i128;
         
@@ -668,8 +668,8 @@ mod tests {
                 payment_id,
                 String::from_str(&env, "Refund while paused")
             );
-=======
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         
         // Different user tries to request refund
         let other_user = TestAddress::generate(&env);
@@ -691,7 +691,7 @@ mod tests {
         let amount = 1000i128;
         
         // Make payment and request refund
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &amount);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         let reason = String::from_str(&env, "duplicate_payment");
         let request_id = client.request_refund(&user, &payment_id, &reason);
         
@@ -734,7 +734,7 @@ mod tests {
         let meter_id = String::from_str(&env, "METER-001");
         let amount = 2000i128;
         
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &amount);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         let reason = String::from_str(&env, "user_error");
         let request_id = client.request_refund(&user, &payment_id, &reason);
         
@@ -760,7 +760,7 @@ mod tests {
         let token_address = TestAddress::generate(&env);
         let meter_id = String::from_str(&env, "METER-001");
         
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         let reason = String::from_str(&env, "incorrect_amount");
         let request_id = client.request_refund(&user, &payment_id, &reason);
         
@@ -783,7 +783,7 @@ mod tests {
         let token_address = TestAddress::generate(&env);
         let meter_id = String::from_str(&env, "METER-001");
         
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         let reason = String::from_str(&env, "wrong_meter_id");
         let request_id = client.request_refund(&user, &payment_id, &reason);
         
@@ -810,7 +810,7 @@ mod tests {
         let token_address = TestAddress::generate(&env);
         let meter_id = String::from_str(&env, "METER-001");
         
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         let reason = String::from_str(&env, "duplicate_payment");
         let request_id = client.request_refund(&user, &payment_id, &reason);
         
@@ -854,7 +854,7 @@ mod tests {
         let token_address = TestAddress::generate(&env);
         let meter_id = String::from_str(&env, "METER-001");
         
-        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &1000);
+        let payment_id = client.pay_bill(&user, &token_address, &meter_id, &, &None, &String::from_str(&env, "nonce_test"));
         let reason = String::from_str(&env, "wrong_meter_id");
         let request_id = client.request_refund(&user, &payment_id, &reason);
         
@@ -866,7 +866,7 @@ mod tests {
         let reason2 = String::from_str(&env, "another_reason");
         let result = std::panic::catch_unwind(|| {
             client.request_refund(&user, &payment_id, &reason2);
->>>>>>> 7c6957b887aad2d7d8e9ecedd6292ce5fc776e6f
+
         });
         assert!(result.is_err());
         

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -34,6 +34,7 @@ export interface PaymentRequest {
   amount: number;
   userId: string;
   memo?: string; // Optional memo for transaction identification
+  nonce: string; // Unique nonce to prevent replay attacks
   timestamp?: string; // ISO string for consistency
 }
 


### PR DESCRIPTION
…acks

- Add nonce field to PaymentRequest and PaymentRecord
- Update pay_bill contract function to validate nonce uniqueness
- Store used nonces in contract storage to prevent reuse
- Update backend and client interfaces to include nonce
- Addresses issue #117: Transaction Replay Attack Vector

Closes #117