### PR TITLE
fix(frontend): implement dynamic fee calculation for transactions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -138,7 +138,7 @@ const Home = memo(() => {
 
       const account = await server.loadAccount(pubKeyString);
       const transactionBuilder = new TransactionBuilder(account, {
-        fee: BASE_FEE,
+        fee: feeEstimate ? feeEstimate.baseFee.toString() : BASE_FEE,
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.payment({

--- a/frontend/src/hooks/useRating.ts
+++ b/frontend/src/hooks/useRating.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { Server, Networks, TransactionBuilder, Operation, BASE_FEE } from '@stellar/stellar-sdk';
 import { isConnected, requestAccess, signTransaction } from "@stellar/freighter-api";
 import { getCurrentNetworkConfig } from '../utils/network-config';
+import { feeEstimationService } from '../services/feeEstimation';
 
 export interface Review {
   reviewer: string;
@@ -26,6 +27,15 @@ export interface RatingHookReturn {
   isLoading: boolean;
   error: string | null;
 }
+
+const getDynamicFee = async (): Promise<string> => {
+  try {
+    const fees = await feeEstimationService.getNetworkFees();
+    return fees.recommendedFee.toString();
+  } catch (error) {
+    return BASE_FEE;
+  }
+};
 
 export const useRating = (): RatingHookReturn => {
   const [isLoading, setIsLoading] = useState(false);
@@ -70,7 +80,7 @@ export const useRating = (): RatingHookReturn => {
       // In a real implementation, you might want to use a small XLM transfer
       // or create a custom transaction type for reviews
       const transaction = new TransactionBuilder(account, {
-        fee: BASE_FEE,
+        fee: await getDynamicFee(),
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.payment({
@@ -95,7 +105,7 @@ export const useRating = (): RatingHookReturn => {
       const contract = new Contract(networkConfig.contractId);
       
       const reviewTx = new TransactionBuilder(account, {
-        fee: BASE_FEE,
+        fee: await getDynamicFee(),
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.invokeContractFunction({
@@ -141,7 +151,7 @@ export const useRating = (): RatingHookReturn => {
       const contract = new Contract(networkConfig.contractId);
       
       const tx = new TransactionBuilder(new Account(networkConfig.contractId, '1'), {
-        fee: BASE_FEE,
+        fee: await getDynamicFee(),
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.invokeContractFunction({
@@ -183,7 +193,7 @@ export const useRating = (): RatingHookReturn => {
       const contract = new Contract(networkConfig.contractId);
       
       const tx = new TransactionBuilder(new Account(networkConfig.contractId, '1'), {
-        fee: BASE_FEE,
+        fee: await getDynamicFee(),
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.invokeContractFunction({
@@ -223,7 +233,7 @@ export const useRating = (): RatingHookReturn => {
       const contract = new Contract(networkConfig.contractId);
       
       const tx = new TransactionBuilder(new Account(networkConfig.contractId, '1'), {
-        fee: BASE_FEE,
+        fee: await getDynamicFee(),
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.invokeContractFunction({
@@ -269,7 +279,7 @@ export const useRating = (): RatingHookReturn => {
       const contract = new Contract(networkConfig.contractId);
       
       const tx = new TransactionBuilder(new Account(networkConfig.contractId, '1'), {
-        fee: BASE_FEE,
+        fee: await getDynamicFee(),
         networkPassphrase: networkConfig.networkPassphrase,
       })
         .addOperation(Operation.invokeContractFunction({

--- a/frontend/src/pages/QRPaymentHandler.tsx
+++ b/frontend/src/pages/QRPaymentHandler.tsx
@@ -11,6 +11,7 @@ import { handleOfflineError, getOfflineErrorMessage } from '../utils/offlineApi'
 import { announceToScreenReader } from '../utils/accessibility';
 import { logger } from '../utils/logger';
 import { TransactionBuilder, Operation, Asset, BASE_FEE, Horizon } from '@stellar/stellar-sdk';
+import { feeEstimationService } from '../services/feeEstimation';
 
 interface QRPaymentData {
   meterId: string;
@@ -111,12 +112,16 @@ export const QRPaymentHandler: React.FC = () => {
       if ((window as any).__MOCK_STELLAR_TRANSACTION__) {
         transaction = (window as any).__MOCK_STELLAR_TRANSACTION__(account, paymentData.amount);
       } else {
+        const dest = "GDOPTS553GBKXNF3X4YCQ7NPZUQ644QAN4SV7JEZHAVOVROAUQTSKEHO";
+        const feeEstimate = await feeEstimationService.estimatePaymentFee(paymentData.amount.toString(), dest).catch(() => null);
+        const dynamicFee = feeEstimate ? feeEstimate.baseFee.toString() : BASE_FEE;
+
         transaction = new TransactionBuilder(account, {
-          fee: BASE_FEE,
+          fee: dynamicFee,
           networkPassphrase: networkConfig.networkPassphrase,
         })
           .addOperation(Operation.payment({
-            destination: "GDOPTS553GBKXNF3X4YCQ7NPZUQ644QAN4SV7JEZHAVOVROAUQTSKEHO",
+            destination: dest,
             asset: Asset.native(),
             amount: paymentData.amount.toString(),
           }))

--- a/frontend/src/services/feeEstimation.ts
+++ b/frontend/src/services/feeEstimation.ts
@@ -87,9 +87,9 @@ export class FeeEstimationService {
       // Fallback to base fee
       return {
         minFee: parseInt(BASE_FEE),
-        recommendedFee: parseInt(BASE_FEE) * 2,
-        p50Fee: parseInt(BASE_FEE) * 3,
-        p90Fee: parseInt(BASE_FEE) * 5
+        recommendedFee: parseInt(BASE_FEE) * 15,
+        p50Fee: parseInt(BASE_FEE) * 50,
+        p90Fee: parseInt(BASE_FEE) * 100
       };
     }
   }
@@ -179,7 +179,7 @@ export class FeeEstimationService {
         baseFee: parseInt(BASE_FEE),
         totalFee: parseInt(BASE_FEE) / 10000000,
         minFee: parseInt(BASE_FEE) / 10000000,
-        recommendedFee: (parseInt(BASE_FEE) * 2) / 10000000,
+        recommendedFee: (parseInt(BASE_FEE) * 15) / 10000000,
         operationCount: 1,
         estimatedTime: 5
       };
@@ -191,7 +191,7 @@ export class FeeEstimationService {
    */
   async estimateComplexTransactionFee(
     operations: Operation[],
-    fee: number = parseInt(BASE_FEE) * 2
+    fee: number = parseInt(BASE_FEE) * 15
   ): Promise<FeeEstimate> {
     try {
       const accessResult = await requestAccess();
@@ -233,7 +233,7 @@ export class FeeEstimationService {
         baseFee: fee,
         totalFee: (fee * operations.length) / 10000000,
         minFee: parseInt(BASE_FEE) / 10000000,
-        recommendedFee: (parseInt(BASE_FEE) * 2) / 10000000,
+        recommendedFee: (parseInt(BASE_FEE) * 15) / 10000000,
         operationCount: operations.length,
         estimatedTime: 5
       };
@@ -244,11 +244,10 @@ export class FeeEstimationService {
    * Estimate confirmation time based on fee
    */
   private estimateConfirmationTime(feeStroops: number): number {
-    // Simple heuristic based on fee amount
-    if (feeStroops >= 500) return 3; // High priority
-    if (feeStroops >= 200) return 5; // Medium priority
-    if (feeStroops >= 100) return 10; // Low priority
-    return 15; // Very low priority
+    if (feeStroops >= 5000) return 3;     // Dynamic threshold approximation
+    if (feeStroops >= 1500) return 5;
+    if (feeStroops >= 500) return 10;
+    return 15;
   }
 
   /**


### PR DESCRIPTION
Closes #125 
- Update App.tsx and QRPaymentHandler.tsx to use dynamically estimated fees rather than hardcoded BASE_FEE
- Refactor useRating.ts smart contract calls to fetch and apply network fees conditionally
- Increase fallback fee multipliers in feeEstimation.ts to prevent transaction drops during network congestion and API failures