### PR TITLE
test: add backend test data factories

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.0.0",
         "ioredis": "^5.10.1",
         "js-yaml": "^4.1.1",
+        "nodemailer": "^6.9.7",
         "pg": "^8.11.3",
         "swagger-ui-express": "^5.0.1",
         "web-push": "^3.6.7",
@@ -31,6 +32,7 @@
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.0",
+        "@types/nodemailer": "^6.4.14",
         "@types/pg": "^8.10.7",
         "@types/supertest": "^6.0.2",
         "@types/ws": "^8.5.6",
@@ -6503,6 +6505,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.23",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pako": {
@@ -13579,6 +13591,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -1,14 +1,7 @@
-// Mock environment variables — must be set BEFORE any module that imports envConfig
-process.env.NODE_ENV = 'test';
-process.env.PORT = '3001';
-process.env.NETWORK = 'testnet';
-process.env.CONTRACT_ID_TESTNET = 'CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA';
-process.env.RPC_URL_TESTNET = 'https://soroban-testnet.stellar.org';
-process.env.NETWORK_PASSPHRASE_TESTNET = 'Test SDF Network ; September 2015';
-// Required by envConfig validation
-process.env.ADMIN_SECRET_KEY = 'SCZANGBA5RLKJZ65NOCRQSMUXNK3LSNZEOZ5WLBAOWCA6ZXHM7NIYFP4';
-process.env.SECRET_KEY = process.env.ADMIN_SECRET_KEY; // payment-service.ts alias
-process.env.API_KEY = 'test-api-key-for-jest-suite';
+import { applyTestEnv } from './testData';
+
+// Shared deterministic test env for backend suites.
+applyTestEnv();
 
 // Mock Stellar SDK
 jest.mock('@stellar/stellar-sdk', () => ({

--- a/backend/src/test/testData.test.ts
+++ b/backend/src/test/testData.test.ts
@@ -1,0 +1,64 @@
+import { createTestDataFactory, applyTestEnv } from './testData';
+
+describe('test data factory', () => {
+  it('creates deterministic payment requests with unique IDs', () => {
+    const factory = createTestDataFactory({ seed: 'suite' });
+
+    const requests = factory.paymentRequests(3, (index) => ({
+      amount: 50 + index,
+      userId: 'shared-user',
+    }));
+
+    expect(requests).toEqual([
+      expect.objectContaining({
+        meter_id: 'METER-002',
+        amount: 50,
+        userId: 'shared-user',
+        nonce: 'suite-nonce-003',
+      }),
+      expect.objectContaining({
+        meter_id: 'METER-005',
+        amount: 51,
+        userId: 'shared-user',
+        nonce: 'suite-nonce-006',
+      }),
+      expect.objectContaining({
+        meter_id: 'METER-008',
+        amount: 52,
+        userId: 'shared-user',
+        nonce: 'suite-nonce-009',
+      }),
+    ]);
+  });
+
+  it('resets generated data for repeatable test setup', () => {
+    const factory = createTestDataFactory({ seed: 'reset' });
+    const first = factory.paymentRequest();
+
+    factory.reset();
+
+    expect(factory.paymentRequest()).toEqual(first);
+  });
+
+  it('creates reusable rate limit config overrides', () => {
+    const factory = createTestDataFactory();
+
+    expect(factory.rateLimitConfig({ maxRequests: 2 })).toEqual({
+      windowMs: 60_000,
+      maxRequests: 2,
+      queueSize: 10,
+    });
+  });
+
+  it('applies and restores test environment values', () => {
+    const originalApiKey = process.env.API_KEY;
+    const restore = applyTestEnv({ API_KEY: 'override-key', SECRET_KEY: undefined });
+
+    expect(process.env.API_KEY).toBe('override-key');
+    expect(process.env.SECRET_KEY).toBeUndefined();
+
+    restore();
+
+    expect(process.env.API_KEY).toBe(originalApiKey);
+  });
+});

--- a/backend/src/test/testData.ts
+++ b/backend/src/test/testData.ts
@@ -1,0 +1,133 @@
+import type { PaymentRequest } from '../payment-service';
+import type { RateLimitConfig } from '../rate-limiter';
+
+type EnvValue = string | undefined;
+
+export interface TestUser {
+  id: string;
+  email: string;
+  publicKey: string;
+}
+
+export interface TestMeter {
+  id: string;
+  type: 'electricity' | 'water' | 'gas';
+}
+
+export interface TestDataFactoryOptions {
+  seed?: string;
+}
+
+export class TestDataFactory {
+  private sequence = 0;
+  private readonly seed: string;
+
+  constructor(options: TestDataFactoryOptions = {}) {
+    this.seed = options.seed ?? 'wata-test';
+  }
+
+  reset(): void {
+    this.sequence = 0;
+  }
+
+  user(overrides: Partial<TestUser> = {}): TestUser {
+    const id = this.nextId('user');
+    return {
+      id,
+      email: `${id}@example.test`,
+      publicKey: 'GTEST1234567890abcdef1234567890abcdef12345678',
+      ...overrides,
+    };
+  }
+
+  meter(overrides: Partial<TestMeter> = {}): TestMeter {
+    const index = this.nextSequence();
+    return {
+      id: `METER-${String(index).padStart(3, '0')}`,
+      type: 'electricity',
+      ...overrides,
+    };
+  }
+
+  paymentRequest(overrides: Partial<PaymentRequest> = {}): PaymentRequest {
+    const user = this.user();
+    const meter = this.meter();
+
+    return {
+      meter_id: meter.id,
+      amount: 100,
+      userId: user.id,
+      nonce: this.nextId('nonce'),
+      ...overrides,
+    };
+  }
+
+  paymentRequests(
+    count: number,
+    overrides: Partial<PaymentRequest> | ((index: number) => Partial<PaymentRequest>) = {},
+  ): PaymentRequest[] {
+    return Array.from({ length: count }, (_, index) => {
+      const resolvedOverrides = typeof overrides === 'function' ? overrides(index) : overrides;
+      return this.paymentRequest(resolvedOverrides);
+    });
+  }
+
+  rateLimitConfig(overrides: Partial<RateLimitConfig> = {}): RateLimitConfig {
+    return {
+      windowMs: 60_000,
+      maxRequests: 5,
+      queueSize: 10,
+      ...overrides,
+    };
+  }
+
+  private nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  private nextId(prefix: string): string {
+    return `${this.seed}-${prefix}-${String(this.nextSequence()).padStart(3, '0')}`;
+  }
+}
+
+export function createTestDataFactory(options?: TestDataFactoryOptions): TestDataFactory {
+  return new TestDataFactory(options);
+}
+
+export function applyTestEnv(overrides: Record<string, EnvValue> = {}): () => void {
+  const values: Record<string, EnvValue> = {
+    NODE_ENV: 'test',
+    PORT: '3001',
+    NETWORK: 'testnet',
+    CONTRACT_ID_TESTNET: 'CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA',
+    RPC_URL_TESTNET: 'https://soroban-testnet.stellar.org',
+    NETWORK_PASSPHRASE_TESTNET: 'Test SDF Network ; September 2015',
+    ADMIN_SECRET_KEY: 'SCZANGBA5RLKJZ65NOCRQSMUXNK3LSNZEOZ5WLBAOWCA6ZXHM7NIYFP4',
+    SECRET_KEY: 'SCZANGBA5RLKJZ65NOCRQSMUXNK3LSNZEOZ5WLBAOWCA6ZXHM7NIYFP4',
+    API_KEY: 'test-api-key-for-jest-suite',
+    ...overrides,
+  };
+
+  const previousValues = Object.fromEntries(
+    Object.keys(values).map((key) => [key, process.env[key]]),
+  );
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return () => {
+    for (const [key, value] of Object.entries(previousValues)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a typed backend test data factory for payment requests, meters, users, rate-limit config, and test env setup
- reuse the shared env helper from Jest setup so backend suites get one consistent test configuration
- sync the backend lockfile with the package manifest so installs include the declared mail dependencies

## Checks
- npx jest src/test/testData.test.ts --runInBand --coverage=false
- git diff --check

Closes #158