### PR TITLE
feat(payments): cross-provider router with failover saga + finality gating

### DIFF
--- a/backend/src/__tests__/providerRouter.test.ts
+++ b/backend/src/__tests__/providerRouter.test.ts
@@ -1,0 +1,134 @@
+import {
+  routeProviders,
+  processBulkPayment,
+  ProviderRouteInfo,
+  ProviderHealth,
+  PaymentLeg,
+  RouterDeps,
+  SagaEvent,
+} from '../services/providerRouter';
+
+const providers: ProviderRouteInfo[] = [
+  { id: 'A', name: 'A', active: true, successRate: 0.95 },
+  { id: 'B', name: 'B', active: true, successRate: 0.6 },
+  { id: 'C', name: 'C', active: true, successRate: 0.3 },
+];
+
+const allHealthy: ProviderHealth = { isAvailable: () => true };
+
+describe('routeProviders', () => {
+  it('round-robin rotates and repeats deterministically', () => {
+    const cursor = { i: 0 };
+    const order1 = routeProviders(providers, 'round-robin', allHealthy, cursor).map((p) => p.id);
+    const order2 = routeProviders(providers, 'round-robin', allHealthy, cursor).map((p) => p.id);
+    expect(order1).toEqual(['A', 'B', 'C']);
+    expect(order2).toEqual(['B', 'C', 'A']); // rotated
+  });
+
+  it('weighted orders by success rate (best first)', () => {
+    const order = routeProviders(providers, 'weighted', allHealthy).map((p) => p.id);
+    expect(order).toEqual(['A', 'B', 'C']);
+  });
+
+  it('health-gated prefers >=0.8 but falls back if none qualify', () => {
+    const order = routeProviders(providers, 'health-gated', allHealthy).map((p) => p.id);
+    expect(order).toEqual(['A']); // only A >= 0.8
+    const low = providers.map((p) => ({ ...p, successRate: p.successRate * 0.5 }));
+    const fallback = routeProviders(low, 'health-gated', allHealthy).map((p) => p.id);
+    expect(fallback).toEqual(['A', 'B', 'C']); // none >=0.8 -> fallback sorted
+  });
+
+  it('excludes providers whose breaker is open (health gate false)', () => {
+    const health: ProviderHealth = { isAvailable: (id) => id !== 'A' };
+    const order = routeProviders(providers, 'weighted', health).map((p) => p.id);
+    expect(order).toEqual(['B', 'C']); // A excluded
+  });
+});
+
+function makeDeps(
+  submitMap: Record<string, ((leg: PaymentLeg) => Promise<string>) | string | Error>,
+  horizonSealed: Set<string>,
+  overrides: Partial<RouterDeps> = {},
+): { deps: RouterDeps; compensate: jest.Mock; events: SagaEvent[] } {
+  const compensate = jest.fn().mockResolvedValue(undefined);
+  const events: SagaEvent[] = [];
+  const deps: RouterDeps = {
+    submit: async (leg) => {
+      const v = submitMap[leg.providerId];
+      if (v instanceof Error) throw v;
+      if (typeof v === 'function') return await (v as (l: PaymentLeg) => Promise<string>)(leg);
+      return v as string;
+    },
+    compensate,
+    horizon: { isFinalized: async (h) => ({ sealed: horizonSealed.has(h), ledger: horizonSealed.has(h) ? 123 : undefined }) },
+    health: allHealthy,
+    finalityTimeoutMs: 10,
+    finalityPollMs: 1,
+    sleep: async () => { /* instant */ },
+    ...overrides,
+  };
+  return { deps, compensate, events };
+}
+
+describe('processBulkPayment saga', () => {
+  it('settles when all legs succeed and are sealed', async () => {
+    const { deps, events } = makeDeps({ A: 'hA', B: 'hB' }, new Set(['hA', 'hB']));
+    const res = await processBulkPayment(
+      [{ providerId: 'A', meterId: 'm1', amount: 100 }, { providerId: 'B', meterId: 'm2', amount: 50 }],
+      deps,
+      [(e) => events.push(e)],
+    );
+    expect(res.settled).toBe(true);
+    expect(res.finalizationStatus).toBe('confirmed');
+    expect(res.legs.map((l) => l.status)).toEqual(['confirmed', 'confirmed']);
+    expect(deps.compensate).not.toHaveBeenCalled();
+    expect(events.some((e) => e.type === 'BulkPaymentSettled')).toBe(true);
+  });
+
+  it('on a leg failure, compensates already-succeeded legs and aborts', async () => {
+    const { deps, compensate, events } = makeDeps({ A: 'hA', B: new Error('provider B reverted') }, new Set());
+    const res = await processBulkPayment(
+      [{ providerId: 'A', meterId: 'm1', amount: 100 }, { providerId: 'B', meterId: 'm2', amount: 50 }],
+      deps,
+      [(e) => events.push(e)],
+    );
+    expect(res.settled).toBe(false);
+    expect(res.compensated).toBe(true);
+    expect(res.finalizationStatus).toBe('failed');
+    // A submitted then compensated; B failed
+    const statuses = res.legs.map((l) => l.status);
+    expect(statuses).toContain('compensated');
+    expect(statuses).toContain('failed');
+    expect(compensate).toHaveBeenCalledWith('hA');
+    expect(events.some((e) => e.type === 'BulkPaymentCompensated')).toBe(true);
+  });
+
+  it('does not mark confirmed when the ledger is not yet sealed (pending)', async () => {
+    const { deps } = makeDeps({ A: 'hA' }, new Set()); // nothing sealed
+    const res = await processBulkPayment([{ providerId: 'A', meterId: 'm1', amount: 100 }], deps);
+    expect(res.settled).toBe(false);
+    expect(res.finalizationStatus).toBe('pending');
+    expect(res.legs[0].status).toBe('not_sealed');
+  });
+
+  it('breaker-open providers are excluded by routing before submission', async () => {
+    const { deps } = makeDeps({ A: 'hA', B: 'hB' }, new Set(['hA', 'hB']));
+    // route with health that excludes A; choose B instead
+    const order = routeProviders(providers, 'weighted', { isAvailable: (id) => id !== 'A' });
+    expect(order[0].id).toBe('B');
+    // submit to the routed provider (B), which succeeds+seals
+    const res = await processBulkPayment([{ providerId: order[0].id, meterId: 'm', amount: 1 }], deps);
+    expect(res.settled).toBe(true);
+  });
+
+  it('compensation failure leaves the leg pending (needs manual reconciliation)', async () => {
+    const { deps, compensate } = makeDeps({ A: 'hA', B: new Error('boom') }, new Set());
+    compensate.mockRejectedValueOnce(new Error('refund failed'));
+    const res = await processBulkPayment(
+      [{ providerId: 'A', meterId: 'm1', amount: 100 }, { providerId: 'B', meterId: 'm2', amount: 50 }],
+      deps,
+    );
+    expect(res.compensated).toBe(false); // compensation failed
+    expect(res.legs.find((l) => l.providerId === 'A')!.status).toBe('pending');
+  });
+});

--- a/backend/src/services/providerRouter.ts
+++ b/backend/src/services/providerRouter.ts
@@ -1,0 +1,203 @@
+/**
+ * Cross-provider payment router with deterministic failover, settlement
+ * finality gating, and a partial-failure saga with compensation.
+ *
+ * Additive to MultiProviderPaymentService: this module provides the routing
+ * strategy, the bulk-payment saga, and finality polling. All external
+ * dependencies (submission, compensation, horizon finality, provider health)
+ * are injected so the module is fully unit-testable without Stellar.
+ */
+
+export type SelectionStrategy = 'round-robin' | 'weighted' | 'health-gated';
+
+export type LegStatus = 'pending' | 'confirmed' | 'failed' | 'compensated' | 'not_sealed';
+
+export interface ProviderRouteInfo {
+  id: string;
+  name: string;
+  active: boolean;
+  /** Recent success rate 0..1, used by the weighted + health-gated strategies. */
+  successRate: number;
+}
+
+/** Health gate — returns false when a provider's breaker is open / unhealthy. */
+export interface ProviderHealth {
+  isAvailable(providerId: string): boolean;
+}
+
+export interface PaymentLeg {
+  providerId: string;
+  meterId: string;
+  amount: number;
+}
+
+export interface SubmittedLeg {
+  providerId: string;
+  transactionHash: string;
+  status: LegStatus;
+  ledger?: number;
+  error?: string;
+}
+
+export interface BulkPaymentResult {
+  legs: SubmittedLeg[];
+  settled: boolean;
+  compensated: boolean;
+  finalizationStatus: 'confirmed' | 'pending' | 'failed';
+}
+
+export interface RouterDeps {
+  /** Submit one leg to its provider; resolves with a transaction hash. */
+  submit: (leg: PaymentLeg) => Promise<string>;
+  /** Compensate (refund) an already-submitted leg by its transaction hash. */
+  compensate: (transactionHash: string) => Promise<void>;
+  /** Poll horizon for ledger finality of a transaction. */
+  horizon: { isFinalized(transactionHash: string): Promise<{ sealed: boolean; ledger?: number }> };
+  /** Provider health / circuit-breaker gate. */
+  health: ProviderHealth;
+  /** Per-leg finality polling budget. */
+  finalityTimeoutMs?: number;
+  /** Interval between finality polls. */
+  finalityPollMs?: number;
+  /** Clock for sleeps (ms) — injectable for fast tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type SagaEvent =
+  | { type: 'BulkPaymentSettled'; legs: SubmittedLeg[] }
+  | { type: 'BulkPaymentCompensated'; failed: SubmittedLeg; compensated: SubmittedLeg[] }
+  | { type: 'LegSubmitted'; leg: SubmittedLeg }
+  | { type: 'LegFailed'; providerId: string; error: string };
+
+export type SagaEventListener = (event: SagaEvent) => void;
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Order providers for routing / failover according to the strategy. Providers
+ * whose health gate reports unavailable (open breaker) are excluded.
+ */
+export function routeProviders(
+  providers: ProviderRouteInfo[],
+  strategy: SelectionStrategy,
+  health: ProviderHealth,
+  rrCursor: { i: number } = { i: 0 },
+): ProviderRouteInfo[] {
+  const available = providers.filter((p) => p.active && health.isAvailable(p.id));
+  if (!available.length) return [];
+
+  switch (strategy) {
+    case 'round-robin': {
+      const start = ((rrCursor.i % available.length) + available.length) % available.length;
+      rrCursor.i = start + 1;
+      const ordered = [...available.slice(start), ...available.slice(0, start)];
+      return ordered;
+    }
+    case 'weighted': {
+      // Weighted by success rate (desc), with a small floor so a 0-rate provider
+      // can still be tried as failover rather than never used.
+      return [...available].sort((a, b) => (b.successRate + 0.05) - (a.successRate + 0.05));
+    }
+    case 'health-gated': {
+      // Only providers above a success-rate threshold, sorted by success rate.
+      const gated = available.filter((p) => p.successRate >= 0.8);
+      const pool = gated.length ? gated : available; // fall back if none qualify
+      return [...pool].sort((a, b) => b.successRate - a.successRate);
+    }
+    default:
+      return available;
+  }
+}
+
+/**
+ * Bulk-payment saga. Submits each leg to its provider; on the first leg failure
+ * it compensates (refunds) all already-submitted legs and aborts. Successful
+ * submissions are NOT marked confirmed until their ledger is sealed (finality
+ * polling); legs not sealed within the budget stay `not_sealed` and the bulk
+ * result's finalizationStatus is `pending`.
+ */
+export async function processBulkPayment(
+  legs: PaymentLeg[],
+  deps: RouterDeps,
+  listeners: SagaEventListener[] = [],
+): Promise<BulkPaymentResult> {
+  const emit = (e: SagaEvent) => { for (const l of listeners) { try { l(e); } catch { /* ignore */ } } };
+  const submitted: SubmittedLeg[] = [];
+  const finalityTimeoutMs = deps.finalityTimeoutMs ?? 30_000;
+  const pollMs = deps.finalityPollMs ?? 2_000;
+  const sleep = deps.sleep ?? defaultSleep;
+
+  // 1) Submit each leg; fail-fast on the first error, then compensate.
+  for (const leg of legs) {
+    try {
+      const hash = await deps.submit(leg);
+      const s: SubmittedLeg = { providerId: leg.providerId, transactionHash: hash, status: 'pending' };
+      submitted.push(s);
+      emit({ type: 'LegSubmitted', leg: s });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      emit({ type: 'LegFailed', providerId: leg.providerId, error });
+      // Compensate already-submitted legs (reverse order).
+      const compensated: SubmittedLeg[] = [];
+      for (const s of [...submitted].reverse()) {
+        try {
+          await deps.compensate(s.transactionHash);
+          s.status = 'compensated';
+          compensated.push(s);
+        } catch {
+          // compensation failed — leave as pending; needs manual reconciliation.
+          s.status = 'pending';
+        }
+      }
+      const failed: SubmittedLeg = { providerId: leg.providerId, transactionHash: '', status: 'failed', error };
+      emit({ type: 'BulkPaymentCompensated', failed, compensated });
+      return { legs: [...submitted, failed], settled: false, compensated: compensated.length > 0, finalizationStatus: 'failed' };
+    }
+  }
+
+  // 2) Finality gating: do not mark confirmed until each ledger is sealed.
+  let allSealed = true;
+  for (const s of submitted) {
+    const deadline = Date.now() + finalityTimeoutMs;
+    let sealed = false;
+    while (Date.now() < deadline) {
+      const res = await deps.horizon.isFinalized(s.transactionHash);
+      if (res.sealed) {
+        sealed = true;
+        s.status = 'confirmed';
+        s.ledger = res.ledger;
+        break;
+      }
+      await sleep(pollMs);
+    }
+    if (!sealed) {
+      s.status = 'not_sealed';
+      allSealed = false;
+    }
+  }
+
+  if (allSealed) {
+    emit({ type: 'BulkPaymentSettled', legs: submitted });
+    return { legs: submitted, settled: true, compensated: false, finalizationStatus: 'confirmed' };
+  }
+  // Sealed partially or none yet — stay pending; legs carry their own status.
+  return { legs: submitted, settled: false, compensated: false, finalizationStatus: 'pending' };
+}
+
+/**
+ * Adapter that backs ProviderHealth with the existing CircuitBreaker instances.
+ * A provider is "available" when its breaker is not OPEN.
+ */
+export function circuitBreakerHealth(
+  breakers: Map<string, { getState(): { name: string; state: string } | string }>,
+): ProviderHealth {
+  return {
+    isAvailable(providerId: string): boolean {
+      const b = breakers.get(providerId);
+      if (!b) return true;
+      const state: any = (b as any).getState?.();
+      const stateValue = typeof state === 'object' && state ? (state as any).state : state;
+      return stateValue !== 'OPEN';
+    },
+  };
+}

--- a/docs/CROSS_PROVIDER_ROUTER.md
+++ b/docs/CROSS_PROVIDER_ROUTER.md
@@ -1,0 +1,43 @@
+# Cross-Provider Payment Router & Saga
+
+`backend/src/services/providerRouter.ts` (additive to `MultiProviderPaymentService`)
+provides deterministic provider routing, a partial-failure compensation saga, and
+settlement-finality gating for bulk/multi-provider payments.
+
+## Provider selection strategies (pluggable)
+- `round-robin` — rotates the available provider set; deterministic.
+- `weighted` — orders by success rate (best first), with a small floor so a
+  0-rate provider can still be a failover target.
+- `health-gated` — only providers with success rate >= 0.8, sorted by rate;
+  falls back to the full set if none qualify.
+
+`routeProviders(providers, strategy, health)` excludes providers whose
+`ProviderHealth.isAvailable(id)` is false — i.e. an open circuit breaker. A
+`circuitBreakerHealth()` adapter backs `ProviderHealth` with the existing
+`CircuitBreaker` instances (OPEN => unavailable).
+
+## Bulk-payment saga (`processBulkPayment`)
+1. Submits each leg via `submit(leg)`. On the **first leg failure**, it
+   aborts and **compensates** (refunds) all already-submitted legs in reverse
+   order, emitting `BulkPaymentCompensated`. (A compensation failure leaves the
+   leg `pending` for manual reconciliation.)
+2. **Finality gating**: does not mark a leg `confirmed` until its ledger is
+   sealed. Polls `horizon.isFinalized(hash)` until sealed or the per-leg budget
+   expires; unsealed legs become `not_sealed` and the bulk result is `pending`.
+3. Emits `BulkPaymentSettled` only when every leg is sealed.
+
+## Events
+`BulkPaymentSettled`, `BulkPaymentCompensated`, `LegSubmitted`, `LegFailed`.
+Listeners are isolated (a throwing listener never breaks the saga).
+
+## Tests (`backend/src/__tests__/providerRouter.test.ts`)
+- round-robin rotation; weighted ordering; health-gated threshold + fallback.
+- breaker-open provider excluded from routing.
+- A succeeds / B reverts -> A compensated.
+- ledger-not-yet-sealed -> `pending` (not confirmed).
+- compensation failure -> leg stays `pending`.
+
+## Follow-ups
+- Persist the saga state machine (e.g. `bulk_payment_legs` table) so a backend
+  restart can resume compensation.
+- Real horizon finality client + ledger-sequence monotonicity as the seal signal.


### PR DESCRIPTION
Closes #329

## What
Additive `backend/src/services/providerRouter.ts`: deterministic provider routing, a partial-failure compensation saga, and settlement-finality gating for multi-provider payments.

## Provider selection (pluggable)
- `round-robin` (deterministic rotation), `weighted` (success-rate, best-first), `health-gated` (>=0.8 threshold + fallback).
- `routeProviders()` excludes providers whose `ProviderHealth.isAvailable(id)` is false (open circuit breaker). `circuitBreakerHealth()` adapter backs it with the existing `CircuitBreaker` instances.

## Bulk-payment saga (`processBulkPayment`)
1. Submits each leg via injected `submit`. **Fail-fast**: on first leg failure, aborts and **compensates (refunds)** already-submitted legs in reverse order → `BulkPaymentCompensated`. A compensation failure leaves the leg `pending` for manual reconciliation.
2. **Finality gating**: a leg is not `confirmed` until `horizon.isFinalized(hash)` reports the ledger sealed; unsealed legs → `not_sealed` and the bulk `finalizationStatus` is `pending`.
3. Emits `BulkPaymentSettled` only when every leg is sealed.

## Acceptance criteria coverage
- [x] Pluggable selection strategies (round-robin, weighted-by-success-rate, health-gated), configurable.
- [x] Saga: per-leg `Pending` → on failure, `Refunded` compensation for already-succeeded legs; `BulkPaymentSettled`/`BulkPaymentCompensated` events.
- [x] Not `Confirmed` until ledger finalized; exposes `finalizationStatus` (confirmed/pending/failed) + per-leg status.
- [x] Per-provider circuit-breaker integration (breaker-open providers excluded from routing).
- [x] Tests: A succeeds/B reverts → A compensated; ledger-not-closed → `Pending`; breaker-open provider excluded.

## Verification
- `npx jest src/__tests__/providerRouter.test.ts` → **9/9 passing** (routing strategies, breaker exclusion, saga compensation, finality pending, compensation-failure path).
- New TS compiles via ts-jest. (Backend has pre-existing unrelated `tsc` errors in `payment-service.ts`/`multiProviderPaymentService.ts`.)

## Out of scope / follow-ups
- Persist saga state (e.g. `bulk_payment_legs` table) to resume compensation after a backend restart.
- Real horizon finality client (pluggable `horizon` dep; fake in tests) using ledger-sequence monotonicity.
- Wire the router behind the multi-provider routes (currently additive module + tests; integration wiring is a small follow-up).